### PR TITLE
sshkey: launch new shell given in SHELL envvar

### DIFF
--- a/package/usr/bin/sshkey
+++ b/package/usr/bin/sshkey
@@ -93,4 +93,4 @@ ssh-add ~/.ssh/$SSH_KEY_NAME
 
 echo "$0: starting new shell with ssh-agent"
 
-bash -i
+$SHELL -i


### PR DESCRIPTION
Should solve the issue of opening bash terminal after calling `sshkey` in `zsh` shell