### PR TITLE
Update tmux.conf to remap the choose session shortcut to Ctrl+S

### DIFF
--- a/package/etc/ctu-mrs/tmux.conf
+++ b/package/etc/ctu-mrs/tmux.conf
@@ -50,6 +50,9 @@ bind -n S-Left prev
 # make delay shorter
 set -sg escape-time 0
 
+# Switch between tmux sessions
+bind S choose-session
+
 # Toggle synchronize-panes with ^S m
 bind s \
     set synchronize-panes \;\


### PR DESCRIPTION
Restores the original tmux session-switching behavior by binding it to <kbd>Ctrl-b</kbd> + <kbd>Shift+s</kbd>.

Previously, <kbd>Ctrl-b</kbd> + <kbd>s</kbd> was repurposed to toggle pane synchronization. While useful, this overrides tmux’s default session navigation shortcut within the same socket.

To resolve the conflict:

Pane synchronization remains available on lowercase <kbd>s</kbd>.

Session switching is reintroduced on uppercase <kbd>S</kbd> (i.e., <kbd>Ctrl-b</kbd> + <kbd>Shift+S</kbd>), preserving the original tmux behavior.

This keeps both features accessible without overlap and aligns more closely with tmux defaults.